### PR TITLE
Fix Qt dialog example failing to work in optimized builds

### DIFF
--- a/QT5 Device Selection and Property Dialogs in C++/qt5-camera-dialogs/tcamcamera.cpp
+++ b/QT5 Device Selection and Property Dialogs in C++/qt5-camera-dialogs/tcamcamera.cpp
@@ -401,8 +401,8 @@ TcamCamera::initialize_format_list()
                 assert(min && max);
                 fmt.framerate_min.numerator = gst_value_get_fraction_numerator(min);
                 fmt.framerate_min.denominator = gst_value_get_fraction_denominator(min);
-                fmt.framerate_min.numerator = gst_value_get_fraction_numerator(min);
-                fmt.framerate_min.denominator = gst_value_get_fraction_denominator(min);
+                fmt.framerate_max.numerator = gst_value_get_fraction_numerator(max);
+                fmt.framerate_max.denominator = gst_value_get_fraction_denominator(max);
             }
             else
             {

--- a/QT5 Device Selection and Property Dialogs in C++/qt5-camera-dialogs/tcamcamera.cpp
+++ b/QT5 Device Selection and Property Dialogs in C++/qt5-camera-dialogs/tcamcamera.cpp
@@ -9,6 +9,7 @@
 
 #include <iostream>
 
+#include <QDebug>
 #include <assert.h>
 
 using namespace gsttcam;
@@ -297,7 +298,10 @@ TcamCamera::create_pipeline()
 
     gst_bin_add_many(GST_BIN(pipeline_),
                      tcambin_, capturecapsfilter_, tee_, queue, capturesink_, nullptr);
-    assert(gst_element_link_many(tcambin_, capturecapsfilter_, tee_, queue, capturesink_, nullptr));
+    const auto ret = gst_element_link_many(tcambin_, capturecapsfilter_, tee_, queue, capturesink_, nullptr);
+    assert(ret);
+    if (!ret)
+        qCritical() << "Unable to link pipeline";
 }
 
 void


### PR DESCRIPTION
Hi!
There was a lot of confusion when my code worked fine on my development computer, but failed to work properly in production (black screen, no video signal arrived at the sink, and eventually an error message that the camera wasn't responding). After a lot of fault-finding in the GStreamer pipeline I eventually discovered that building the code with assertions disabled caused this problem.

Since the problematic code was copied from this example, I thought it might be good to send this PR back to fix it, because this is a pretty neat trap that has been set for people to walk into ^^

Background is that anything in an assert() statement is optimized away completely by design, and unfortunately one of the assertions directly wrapped the crucial step of linking the GStreamer pipeline, which resulted in some very odd errors which initially made me look for the issue in all the wrong places.

While looking for the issue, I also found a spot where the maximum framerate in the format list for a new camera wasn't set properly, which highly likely is a typo/copy error. So this PR resolves this too.

Thank you very much for writing the examples and for open-sourcing almost every part of the imaging pipeline - this is of great help for us, and allows us to use the devices better.

I hope you will find this PR useful.
With kind regards,
    Matthias