### PR TITLE
Adding resolution property to ResDesc class in python-common/TIS.py.

### DIFF
--- a/python/capture-sequence/TIS.py
+++ b/python/capture-sequence/TIS.py
@@ -452,6 +452,7 @@ class ResDesc:
         self.width = width
         self.height = height
         self.fps = fps
+        self.resolution=f"{width}x{height}"
 
 
 class FmtDesc:

--- a/python/python-common/TIS.py
+++ b/python/python-common/TIS.py
@@ -425,8 +425,6 @@ class ResDesc:
         self.resolution=f"{width}x{height}"
 
 
-
-
 class FmtDesc:
     """"""
 

--- a/python/python-common/TIS.py
+++ b/python/python-common/TIS.py
@@ -422,6 +422,9 @@ class ResDesc:
         self.width = width
         self.height = height
         self.fps = fps
+        self.resolution=f"{width}x{height}"
+
+
 
 
 class FmtDesc:


### PR DESCRIPTION
As explained in #40, the `ResDesc` did not had a `resolution` attribute which is required during the use of instances of `ResDesc` in the  `FmtDesc` class in `python-common/TIS.py`.